### PR TITLE
Fixed fetchData when object is empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 package-lock.json
 main.db
+.idea/

--- a/fetcher.js
+++ b/fetcher.js
@@ -132,10 +132,14 @@ class WBSearch {
         try {
             let response = await fetch(url)
             let jsonData = await response.json()
+
+            if (jsonData?.data?.products === undefined) {
+                return
+            }
+
             this.positions.push(...jsonData.data.products)
 
-
-            if(jsonData.data.products.length == 300){
+            if (jsonData.data.products.length === 300) {
                 this.params.page += 1
                 if(this.params.page <= 100){
                     await this.fetchData()


### PR DESCRIPTION
Когда запрашивается страница, на которой нет продуктов запрос на получение возвращает пустой объект.
Пример: [61 страница запроса "бюстгалтер" (с ошибкой специально)](https://search.wb.ru/exactmatch/ru/female/v4/search?query=%D0%B1%D1%8E%D1%81%D1%82%D0%B3%D0%B0%D0%BB%D1%82%D0%B5%D1%80&page=61&regions=69%2C64%2C86%2C83%2C4%2C38%2C30%2C33%2C70%2C22%2C31%2C66%2C68%2C82%2C48%2C1%2C40%2C80&appType=1&locale=ru&dest=-1059500%2C-108082%2C-269701%2C12358048&sort=popular&limit=300&resultset=catalog)